### PR TITLE
added a line to suppress a warning message with supervisor

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,5 @@
 [supervisord]
-user=root
+user = root
 nodaemon = true
 logfile = /dev/stdout
 logfile_maxbytes = 0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,4 +1,5 @@
 [supervisord]
+user=root
 nodaemon = true
 logfile = /dev/stdout
 logfile_maxbytes = 0


### PR DESCRIPTION
Added line in the supervisor config to suppress a warning about running supervisor as root, which we do want to do.